### PR TITLE
feat(invite-email): make OCM invite email optional and improve UI

### DIFF
--- a/lib/ConfigLexicon.php
+++ b/lib/ConfigLexicon.php
@@ -26,7 +26,6 @@ use OCP\IAppConfig;
 class ConfigLexicon implements ILexicon {
 	public const OCM_INVITES_ENABLED = 'ocm_invites_enabled';
 	public const OCM_INVITES_OPTIONAL_MAIL = 'ocm_invites_optional_mail';
-	public const OCM_INVITES_CC_SENDER = 'ocm_invites_cc_sender';
 	public const OCM_INVITES_ENCODED_COPY_BUTTON = 'ocm_invites_encoded_copy_button';
 	public const OCM_INVITES_DISABLE_SSRF_GUARD = 'ocm_invites_disable_ssrf_guard';
 	public const MESH_PROVIDERS_SERVICE = 'mesh_providers_service';
@@ -55,13 +54,6 @@ class ConfigLexicon implements ILexicon {
 				ValueType::BOOL,
 				defaultRaw: false,
 				definition: 'Whether the recipient email field is optional when creating an OCM invite.',
-				lazy: true,
-			),
-			new Entry(
-				self::OCM_INVITES_CC_SENDER,
-				ValueType::BOOL,
-				defaultRaw: true,
-				definition: 'Whether the sender is CC-ed on the OCM invite email.',
 				lazy: true,
 			),
 			new Entry(

--- a/lib/Controller/FederatedInvitesController.php
+++ b/lib/Controller/FederatedInvitesController.php
@@ -161,14 +161,13 @@ class FederatedInvitesController extends Controller {
 	 * @param string $email the recipient email address to send the invitation to (optional)
 	 * @param string $message the optional message to send with the invitation
 	 * @param string $note optional note/label for identifying the invite
-	 * @param bool $ccSender whether to send a copy of the invite to the sender
 	 * @return JSONResponse with data signature ['invite' | 'message'] - the invite url or an error message in case of error.
 	 */
 	#[NoAdminRequired]
 	#[UserRateLimit(limit: 60, period: 3600)]
 	#[BruteForceProtection(action: 'ocmInviteCreate')]
 	#[FrontpageRoute(verb: 'POST', url: '/ocm/invitations')]
-	public function createInvite(string $email = '', string $message = '', string $note = '', bool $ccSender = false): JSONResponse {
+	public function createInvite(string $email = '', string $message = '', string $note = ''): JSONResponse {
 		if (($disabled = $this->requireOcmInvitesEnabled()) !== null) {
 			return $disabled;
 		}
@@ -253,14 +252,6 @@ class FederatedInvitesController extends Controller {
 					return new JSONResponse(['message' => 'An unexpected error occurred creating the invite.'], Http::STATUS_INTERNAL_SERVER_ERROR);
 				}
 				return $response;
-			}
-
-			if ($ccSender && $this->federatedInvitesService->isCcSenderEnabled()) {
-				$response = $this->sendInvitationEmail($token, $senderProvider, $email, $message, true);
-				if ($response->getStatus() !== Http::STATUS_OK) {
-					$this->logger->error('Unable to send copy of email', ['app' => Application::APP_ID]);
-					return new JSONResponse(['message' => 'A copy of the invite could not be sent to you.'], Http::STATUS_INTERNAL_SERVER_ERROR);
-				}
 			}
 		}
 

--- a/lib/Service/FederatedInvitesService.php
+++ b/lib/Service/FederatedInvitesService.php
@@ -52,10 +52,6 @@ class FederatedInvitesService {
 		return $this->appConfig->getValueBool(Application::APP_ID, ConfigLexicon::OCM_INVITES_OPTIONAL_MAIL);
 	}
 
-	public function isCcSenderEnabled(): bool {
-		return $this->appConfig->getValueBool(Application::APP_ID, ConfigLexicon::OCM_INVITES_CC_SENDER);
-	}
-
 	public function isEncodedCopyButtonEnabled(): bool {
 		return $this->appConfig->getValueBool(Application::APP_ID, ConfigLexicon::OCM_INVITES_ENCODED_COPY_BUTTON);
 	}
@@ -70,7 +66,6 @@ class FederatedInvitesService {
 	 */
 	public const OCM_INVITES_BOOL_KEYS = [
 		ConfigLexicon::OCM_INVITES_OPTIONAL_MAIL,
-		ConfigLexicon::OCM_INVITES_CC_SENDER,
 		ConfigLexicon::OCM_INVITES_ENCODED_COPY_BUTTON,
 		ConfigLexicon::OCM_INVITES_DISABLE_SSRF_GUARD,
 	];
@@ -92,7 +87,6 @@ class FederatedInvitesService {
 	public function getOcmInvitesConfig(): array {
 		return [
 			'optionalMail' => $this->isOptionalMailEnabled(),
-			'ccSender' => $this->isCcSenderEnabled(),
 			'encodedCopyButton' => $this->isEncodedCopyButtonEnabled(),
 		];
 	}

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -16,7 +16,7 @@
 			<label for="allow-social-sync">{{ t('contacts', 'Allow updating avatars from social media') }}</label>
 		</p>
 
-		<h3>{{ t('contacts', 'OCM invites') }}</h3>
+		<h3>{{ t('contacts', 'External invitations') }}</h3>
 		<p>
 			<input
 				id="ocm-invites-optional-mail"

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -28,21 +28,12 @@
 		</p>
 		<p>
 			<input
-				id="ocm-invites-cc-sender"
-				v-model="ocmInvitesConfig.ccSender"
-				type="checkbox"
-				class="checkbox"
-				@change="updateOcmSetting(ocmInviteConfigKeys.ccSender, ocmInvitesConfig.ccSender)">
-			<label for="ocm-invites-cc-sender">{{ t('contacts', 'Offer the option to also send a copy of the invite to the sender') }}</label>
-		</p>
-		<p>
-			<input
 				id="ocm-invites-encoded-copy-button"
 				v-model="ocmInvitesConfig.encodedCopyButton"
 				type="checkbox"
 				class="checkbox"
 				@change="updateOcmSetting(ocmInviteConfigKeys.encodedCopyButton, ocmInvitesConfig.encodedCopyButton)">
-			<label for="ocm-invites-encoded-copy-button">{{ t('contacts', 'Show the "Copy encoded invite code" button on invite details') }}</label>
+			<label for="ocm-invites-encoded-copy-button">{{ t('contacts', 'Show the "Copy encoded invite" button on invite details') }}</label>
 		</p>
 	</div>
 </template>
@@ -62,7 +53,6 @@ export default {
 			ocmInviteConfigKeys: OCM_INVITES_CONFIG_KEYS,
 			ocmInvitesConfig: loadState('contacts', 'ocmInvitesConfig', {
 				optionalMail: false,
-				ccSender: true,
 				encodedCopyButton: false,
 			}),
 		}

--- a/src/components/AppContent/OcmInvitesContent.vue
+++ b/src/components/AppContent/OcmInvitesContent.vue
@@ -5,7 +5,7 @@
 
 <template>
 	<AppContent v-if="loading">
-		<EmptyContent class="empty-content" :name="t('contacts', 'Loading invites …')">
+		<EmptyContent class="empty-content" :name="t('contacts', 'Loading invites...')">
 			<template #icon>
 				<IconLoading :size="20" />
 			</template>

--- a/src/components/AppNavigation/RootNavigation.vue
+++ b/src/components/AppNavigation/RootNavigation.vue
@@ -94,25 +94,47 @@
 				</template>
 			</AppNavigationItem>
 
-			<!-- All OCM invites -->
-			<AppNavigationItem
-				v-if="isOcmInvitesEnabled"
-				id="ocm-invites"
-				:name="GROUP_ALL_OCM_INVITES"
-				:to="{
-					name: ROUTE_NAME_ALL_OCM_INVITES,
-				}"
-				:active="routeState === 'ocm-invites'"
-				@click="updateRouteState('ocm-invites')">
-				<template #icon>
-					<IconAccountSwitchOutline :size="20" />
-				</template>
-				<template #counter>
-					<NcCounterBubble
-						v-if="ocmInvites.length"
-						:count="ocmInvites.length" />
-				</template>
-			</AppNavigationItem>
+			<template v-if="isOcmInvitesEnabled">
+				<AppNavigationCaption
+					id="external-invitations"
+					:name="SECTION_EXTERNAL_INVITATIONS">
+					<template #actions>
+						<NcActionButton
+							:disabled="!inviteActionsEnabled"
+							@click="openCreateInvite">
+							<template #icon>
+								<IconAdd :size="20" />
+							</template>
+							{{ t('contacts', 'Create invitation') }}
+						</NcActionButton>
+						<NcActionButton
+							:disabled="!inviteActionsEnabled"
+							@click="openAcceptInvite">
+							<template #icon>
+								<IconAccountArrowDownOutline :size="20" />
+							</template>
+							{{ t('contacts', 'Accept invitation') }}
+						</NcActionButton>
+					</template>
+				</AppNavigationCaption>
+				<AppNavigationItem
+					id="ocm-invites"
+					:name="GROUP_ALL_OCM_INVITES"
+					:to="{
+						name: ROUTE_NAME_ALL_OCM_INVITES,
+					}"
+					:active="routeState === 'ocm-invites'"
+					@click="updateRouteState('ocm-invites')">
+					<template #icon>
+						<IconAccountSwitchOutline :size="20" />
+					</template>
+					<template #counter>
+						<NcCounterBubble
+							v-if="ocmInvites.length"
+							:count="ocmInvites.length" />
+					</template>
+				</AppNavigationItem>
+			</template>
 
 			<AppNavigationCaption
 				id="newgroup"
@@ -235,6 +257,7 @@ import {
 import { mapStores } from 'pinia'
 import naturalCompare from 'string-natural-compare'
 import IconUserFilled from 'vue-material-design-icons/Account.vue'
+import IconAccountArrowDownOutline from 'vue-material-design-icons/AccountArrowDownOutline.vue'
 import IconContactFilled from 'vue-material-design-icons/AccountMultiple.vue'
 import IconContact from 'vue-material-design-icons/AccountMultipleOutline.vue'
 import IconUser from 'vue-material-design-icons/AccountOutline.vue'
@@ -248,7 +271,7 @@ import CircleNavigationItem from './CircleNavigationItem.vue'
 import ContactsSettings from './ContactsSettings.vue'
 import GroupNavigationItem from './GroupNavigationItem.vue'
 import RouterMixin from '../../mixins/RouterMixin.js'
-import { CHART_ALL_CONTACTS, CIRCLE_DESC, CONTACTS_SETTINGS, ELLIPSIS_COUNT, GROUP_ALL_CONTACTS, GROUP_ALL_OCM_INVITES, GROUP_NO_GROUP_CONTACTS, GROUP_RECENTLY_CONTACTED, ROUTE_NAME_ALL_OCM_INVITES, ROUTE_NAME_OCM_INVITE } from '../../models/constants.ts'
+import { CHART_ALL_CONTACTS, CIRCLE_DESC, CONTACTS_SETTINGS, ELLIPSIS_COUNT, GROUP_ALL_CONTACTS, GROUP_ALL_OCM_INVITES, GROUP_NO_GROUP_CONTACTS, GROUP_RECENTLY_CONTACTED, ROUTE_NAME_ALL_OCM_INVITES, ROUTE_NAME_OCM_INVITE, SECTION_EXTERNAL_INVITATIONS } from '../../models/constants.ts'
 import isCirclesEnabled from '../../services/isCirclesEnabled.js'
 import isContactsInteractionEnabled from '../../services/isContactsInteractionEnabled.js'
 import isOcmInvitesEnabled from '../../services/isOcmInvitesEnabled.js'
@@ -270,6 +293,7 @@ export default {
 		Cog,
 		ContactsSettings,
 		GroupNavigationItem,
+		IconAccountArrowDownOutline,
 		IconAccountSwitchOutline,
 		IconContact,
 		IconContactFilled,
@@ -290,7 +314,17 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+
+		inviteActionsEnabled: {
+			type: Boolean,
+			default: false,
+		},
 	},
+
+	emits: [
+		'open-create-invite',
+		'open-accept-invite',
+	],
 
 	data() {
 		return {
@@ -303,6 +337,7 @@ export default {
 			GROUP_RECENTLY_CONTACTED,
 			GROUP_ALL_OCM_INVITES,
 			ROUTE_NAME_ALL_OCM_INVITES,
+			SECTION_EXTERNAL_INVITATIONS,
 
 			// create group
 			isNewGroupMenuOpen: false,
@@ -546,6 +581,20 @@ export default {
 		updateRouteState(state) {
 			this.routeState = state
 		},
+
+		openCreateInvite() {
+			if (!this.inviteActionsEnabled) {
+				return
+			}
+			this.$emit('open-create-invite')
+		},
+
+		openAcceptInvite() {
+			if (!this.inviteActionsEnabled) {
+				return
+			}
+			this.$emit('open-accept-invite')
+		},
 	},
 }
 </script>
@@ -557,6 +606,7 @@ $caption-padding: 22px;
 	padding: calc(var(--default-grid-baseline, 4px) * 2);
 }
 
+#external-invitations,
 #newgroup,
 #newcircle {
 	margin-top: $caption-padding;

--- a/src/components/AppNavigation/RootNavigation.vue
+++ b/src/components/AppNavigation/RootNavigation.vue
@@ -130,8 +130,8 @@
 					</template>
 					<template #counter>
 						<NcCounterBubble
-							v-if="ocmInvites.length"
-							:count="ocmInvites.length" />
+							v-if="pendingOcmInvitesCount"
+							:count="pendingOcmInvitesCount" />
 					</template>
 				</AppNavigationItem>
 			</template>
@@ -389,8 +389,11 @@ export default {
 			return this.userGroupStore.userGroupList
 		},
 
-		ocmInvites() {
-			return this.ocminvitesStore.sortedOcmInvites
+		// Only invitations the recipient has not accepted yet should drive
+		// the navigation badge, so it reads as a pending-action count.
+		pendingOcmInvitesCount() {
+			return Object.values(this.ocminvitesStore.ocmInvites)
+				.filter((invite) => !invite.accepted).length
 		},
 
 		// list all the contacts that doesn't have a group

--- a/src/components/Ocm/OcmAcceptForm.vue
+++ b/src/components/Ocm/OcmAcceptForm.vue
@@ -5,9 +5,6 @@
 
 <template>
 	<div class="ocm_manual_form">
-		<h5>
-			{{ t('contacts', 'Accept invite to exchange contact info.') }}
-		</h5>
 		<p>
 			{{ t('contacts', 'Accepting will add the inviter to your contacts list and in return, your contact info will be sent to the inviter. From there on you can start sharing data with each other.') }}
 		</p>
@@ -15,26 +12,26 @@
 		<div class="ocm_manual_inputs">
 			<NcTextField
 				v-model="invite"
-				:label="t('contacts', 'Invite link, invite code, or encoded invite code (required)')"
+				:label="t('contacts', 'Invite link or code (required)')"
 				type="text"
 				:error="Boolean(error)"
-				:helper-text="error || t('contacts', 'Paste an invite link, invite code (token@provider), or encoded invite code')"
+				:helper-text="error || t('contacts', 'Paste the invite link, or an invite code (token@provider), you received from the other person.')"
 				:required="true" />
 
 			<div class="ocm_manual_buttons">
-				<NcButton :disabled="loadingUpdate" @click="accept">
-					<template #icon>
-						<NcLoadingIcon v-if="loadingUpdate" :size="20" />
-						<IconCheck v-else :size="20" />
-					</template>
-					{{ t('contacts', 'Accept') }}
-				</NcButton>
-				<NcButton :disabled="loadingUpdate" @click="cancel">
+				<NcButton variant="tertiary" :disabled="loadingUpdate" @click="cancel">
 					<template #icon>
 						<NcLoadingIcon v-if="loadingUpdate" :size="20" />
 						<IconCancel v-else :size="20" />
 					</template>
 					{{ t('contacts', 'Cancel') }}
+				</NcButton>
+				<NcButton variant="primary" :disabled="loadingUpdate" @click="accept">
+					<template #icon>
+						<NcLoadingIcon v-if="loadingUpdate" :size="20" />
+						<IconCheck v-else :size="20" />
+					</template>
+					{{ t('contacts', 'Accept') }}
 				</NcButton>
 			</div>
 		</div>
@@ -175,20 +172,21 @@ export default {
 <style lang="scss" scoped>
 .ocm_manual_buttons {
   display: flex;
-  gap: 0.5rem;
+  justify-content: flex-end;
+  gap: calc(var(--default-grid-baseline) * 2);
 }
 
 .ocm_manual_form {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  margin: 1em;
+  gap: calc(var(--default-grid-baseline) * 4);
+  margin: calc(var(--default-grid-baseline) * 4);
   p {
-    margin-bottom: 1em;
+    margin-bottom: calc(var(--default-grid-baseline) * 4);
   }
 
   div.ocm_manual_inputs {
-    margin-inline-start: 0.2em;
+    margin-inline-start: var(--default-grid-baseline);
     width: 80%;
   }
 }

--- a/src/components/Ocm/OcmAttachEmailForm.vue
+++ b/src/components/Ocm/OcmAttachEmailForm.vue
@@ -5,7 +5,6 @@
 
 <template>
 	<div class="contact-header__infos" :aria-busy="loading">
-		<h5>{{ t('contacts', 'Send this invite via email') }}</h5>
 		<p>{{ t('contacts', 'The recipient will receive an email with the invite link. Their email address will be saved on the invite so you can resend later.') }}</p>
 
 		<div class="form-field">
@@ -49,7 +48,7 @@
 				<template #icon>
 					<EmailFastOutlineIcon :size="20" />
 				</template>
-				{{ loading ? t('contacts', 'Sending…') : t('contacts', 'Send') }}
+				{{ loading ? t('contacts', 'Sending...') : t('contacts', 'Send') }}
 			</NcButton>
 		</div>
 	</div>
@@ -125,26 +124,22 @@ export default {
 
 <style lang="scss" scoped>
 .contact-header__infos {
-	margin: 1em;
-
-	h5 {
-		margin: 0 0 0.5em 0;
-	}
+	margin: calc(var(--default-grid-baseline) * 4);
 
 	> p {
-		margin-bottom: 1.5em;
+		margin-bottom: calc(var(--default-grid-baseline) * 6);
 		color: var(--color-text-maxcontrast);
 	}
 
 	.form-field {
-		margin-bottom: 1em;
+		margin-bottom: calc(var(--default-grid-baseline) * 4);
 	}
 
 	.actions {
 		display: flex;
 		justify-content: flex-end;
-		gap: 0.5em;
-		margin-top: 1em;
+		gap: calc(var(--default-grid-baseline) * 2);
+		margin-top: calc(var(--default-grid-baseline) * 4);
 	}
 }
 </style>

--- a/src/components/Ocm/OcmInviteAccept.vue
+++ b/src/components/Ocm/OcmInviteAccept.vue
@@ -5,9 +5,6 @@
 
 <template>
 	<div class="contact-header__infos">
-		<h5>
-			{{ t('contacts', 'Accept invite to exchange contact info.') }}
-		</h5>
 		<p>{{ t('contacts', 'Accepting will add the inviter to your contacts list and in return, your contact info will be sent to the inviter. From there on you can start sharing data with each other.') }}</p>
 		<dl class="invitation-details">
 			<dt>{{ t('contacts', 'Invite code') }}</dt>
@@ -45,27 +42,23 @@ export default {
 
 <style lang="scss" scoped>
 .contact-header__infos {
-	margin: 1em;
-
-	h5 {
-		margin: 0 0 0.5em 0;
-	}
+	margin: calc(var(--default-grid-baseline) * 4);
 
 	> p {
-		margin-bottom: 1.5em;
+		margin-bottom: calc(var(--default-grid-baseline) * 6);
 		color: var(--color-text-maxcontrast);
 	}
 }
 
 .invitation-details {
-	margin: 0 0 1.5em 0;
-	padding: 1em;
+	margin: 0 0 calc(var(--default-grid-baseline) * 6) 0;
+	padding: calc(var(--default-grid-baseline) * 4);
 	background: var(--color-background-dark);
 	border-radius: var(--border-radius-large);
 	display: grid;
 	grid-template-columns: max-content minmax(0, 1fr);
-	column-gap: 1em;
-	row-gap: 0.5em;
+	column-gap: calc(var(--default-grid-baseline) * 4);
+	row-gap: calc(var(--default-grid-baseline) * 2);
 	align-items: baseline;
 
 	dt {
@@ -90,10 +83,10 @@ export default {
 @media (max-width: 480px) {
 	.invitation-details {
 		grid-template-columns: 1fr;
-		row-gap: 0.25em;
+		row-gap: var(--default-grid-baseline);
 
 		dd {
-			margin-bottom: 0.5em;
+			margin-bottom: calc(var(--default-grid-baseline) * 2);
 		}
 	}
 }

--- a/src/components/Ocm/OcmInviteDetails.vue
+++ b/src/components/Ocm/OcmInviteDetails.vue
@@ -18,7 +18,7 @@
 
 		<template v-else>
 			<div class="invite-details">
-				<h2>{{ t('contacts', 'Invitation') }}</h2>
+				<h2>{{ t('contacts', 'External invitation') }}</h2>
 
 				<div class="invite-info">
 					<div v-if="invite.recipientName" class="info-row">
@@ -39,38 +39,30 @@
 					</div>
 				</div>
 
-				<!-- Share buttons -->
-				<details
-					v-if="invite.recipientEmail"
-					:key="inviteKey"
-					class="share-section share-section--collapsible"
-					data-testid="ocm-invite-share-section">
-					<summary class="share-section__summary">
-						<span>{{ t('contacts', 'More ways to share') }}</span>
-					</summary>
-					<p class="share-hint">
-						{{ t('contacts', 'Useful for chat apps and manual acceptance. The recipient already received the invite by email.') }}
-					</p>
-					<OcmInviteShareActions
-						:base64-invite-string="base64InviteString"
-						:clipboard-kinds="clipboardKinds"
-						:encoded-copy-button-enabled="encodedCopyButtonEnabled"
-						:plain-invite-string="plainInviteString"
-						:wayf-link="wayfLink"
-						@copy="onCopyAction" />
-				</details>
-				<div v-else class="share-section" data-testid="ocm-invite-share-section">
-					<h3>{{ t('contacts', 'Share invitation') }}</h3>
-					<p class="share-hint">
-						{{ t('contacts', 'The invite link is the easiest way to share. Invite codes like token@provider are for manual acceptance.') }}
-					</p>
-					<OcmInviteShareActions
-						:base64-invite-string="base64InviteString"
-						:clipboard-kinds="clipboardKinds"
-						:encoded-copy-button-enabled="encodedCopyButtonEnabled"
-						:plain-invite-string="plainInviteString"
-						:wayf-link="wayfLink"
-						@copy="onCopyAction" />
+				<!-- More ways to share (collapsible) -->
+				<div class="more-ways" data-testid="ocm-invite-share-section">
+					<button
+						type="button"
+						class="more-ways__header"
+						:aria-expanded="showShare"
+						data-testid="ocm-invite-share-toggle"
+						@click="showShare = !showShare">
+						<span class="more-ways__title">{{ t('contacts', 'More ways to share') }}</span>
+						<IconChevronUp v-if="showShare" :size="20" />
+						<IconChevronDown v-else :size="20" />
+					</button>
+					<div v-if="showShare" class="more-ways__content">
+						<p class="more-ways__hint">
+							{{ t('contacts', 'Useful for sharing through a chat app or for manual acceptance.') }}
+						</p>
+						<OcmInviteShareActions
+							:invite-link="wayfLink"
+							:invite-code="inviteCode"
+							:encoded-invite="base64InviteString"
+							:clipboard-kinds="clipboardKinds"
+							:encoded-copy-button-enabled="encodedCopyButtonEnabled"
+							@copy="onCopyAction" />
+					</div>
 				</div>
 
 				<!-- Action buttons -->
@@ -135,6 +127,8 @@ import {
 } from '@nextcloud/vue'
 import { mapStores } from 'pinia'
 import IconAccountSwitchOutline from 'vue-material-design-icons/AccountSwitchOutline.vue'
+import IconChevronDown from 'vue-material-design-icons/ChevronDown.vue'
+import IconChevronUp from 'vue-material-design-icons/ChevronUp.vue'
 import EmailFastOutlineIcon from 'vue-material-design-icons/EmailFastOutline.vue'
 import OcmAttachEmailForm from './OcmAttachEmailForm.vue'
 import OcmInviteShareActions from './OcmInviteShareActions.vue'
@@ -152,6 +146,8 @@ export default {
 	components: {
 		EmailFastOutlineIcon,
 		IconAccountSwitchOutline,
+		IconChevronDown,
+		IconChevronUp,
 		Modal,
 		NcAppContentDetails,
 		NcButton,
@@ -170,7 +166,6 @@ export default {
 	data() {
 		const config = loadState('contacts', 'ocmInvitesConfig', {
 			optionalMail: false,
-			ccSender: true,
 			encodedCopyButton: false,
 		})
 		return {
@@ -178,6 +173,7 @@ export default {
 			showAttachEmailForm: false,
 			submittingAttachEmail: false,
 			isComponentMounted: false,
+			showShare: false,
 		}
 	},
 
@@ -210,7 +206,7 @@ export default {
 			return wayfUrl.toString()
 		},
 
-		plainInviteString() {
+		inviteCode() {
 			if (!this.invite) {
 				return ''
 			}
@@ -221,7 +217,7 @@ export default {
 			if (!this.invite) {
 				return ''
 			}
-			return btoa(this.plainInviteString)
+			return btoa(`${this.invite.token}@${this.provider}`)
 		},
 	},
 
@@ -248,11 +244,11 @@ export default {
 				await navigator.clipboard.writeText(text)
 				let message
 				switch (kind) {
+					case CLIPBOARD_KIND_ENCODED_INVITE:
+						message = this.t('contacts', 'Encoded invite copied to clipboard')
+						break
 					case CLIPBOARD_KIND_INVITE_CODE:
 						message = this.t('contacts', 'Invite code copied to clipboard')
-						break
-					case CLIPBOARD_KIND_ENCODED_INVITE:
-						message = this.t('contacts', 'Encoded invite code copied to clipboard')
 						break
 					case CLIPBOARD_KIND_INVITE_LINK:
 						message = this.t('contacts', 'Invite link copied to clipboard')
@@ -335,21 +331,21 @@ export default {
 
 <style lang="scss" scoped>
 .empty-content {
-	margin-top: 5em;
+	margin-top: calc(var(--default-grid-baseline) * 20);
 }
 
 .invite-details {
-	padding: 1.5em;
+	padding: calc(var(--default-grid-baseline) * 6);
 	max-width: 600px;
 
 	h2 {
-		margin: 0 0 1.5em 0;
+		margin: 0 0 calc(var(--default-grid-baseline) * 6) 0;
 		font-size: 1.4em;
 		font-weight: 600;
 	}
 
 	h3 {
-		margin: 0 0 0.75em 0;
+		margin: 0 0 calc(var(--default-grid-baseline) * 3) 0;
 		font-size: 1em;
 		font-weight: 600;
 		color: var(--color-text-maxcontrast);
@@ -357,19 +353,19 @@ export default {
 }
 
 .invite-info {
-	margin-bottom: 2em;
+	margin-bottom: calc(var(--default-grid-baseline) * 8);
 
 	.info-row {
 		display: flex;
-		padding: 0.6em 0;
-		border-bottom: 1px solid var(--color-border-dark);
+		padding: calc(var(--default-grid-baseline) * 2) 0;
+		border-bottom: 1px solid var(--color-border);
 
 		&:last-child {
 			border-bottom: none;
 		}
 
 		.info-label {
-			flex: 0 0 100px;
+			flex: 0 0 calc(var(--default-grid-baseline) * 25);
 			font-weight: 500;
 			color: var(--color-text-maxcontrast);
 		}
@@ -381,67 +377,48 @@ export default {
 	}
 }
 
-.share-section {
-	margin-bottom: 1.5em;
-	padding: calc(var(--default-grid-baseline) * 2);
+.more-ways {
+	margin-bottom: calc(var(--default-grid-baseline) * 6);
 	border: 1px solid var(--color-border);
 	border-radius: var(--border-radius-large);
+	overflow: hidden;
 
-	.share-hint {
-		font-size: 0.85em;
-		color: var(--color-text-maxcontrast);
-		margin: 0 0 0.75em 0;
-	}
-}
-
-.share-section--collapsible {
-	&[open] .share-section__summary::after {
-		transform: rotate(90deg);
-	}
-
-	.share-section__summary {
-		cursor: pointer;
-		user-select: none;
-		font-weight: 600;
-		font-size: 0.95em;
-		color: var(--color-text-maxcontrast);
-		list-style: none;
+	&__header {
 		display: flex;
 		align-items: center;
-		gap: 0.5em;
-		padding: 0.25em 0;
-		border-radius: var(--border-radius);
+		justify-content: space-between;
+		gap: calc(var(--default-grid-baseline) * 2);
+		width: 100%;
+		padding: calc(var(--default-grid-baseline) * 3);
+		border: none;
+		background-color: transparent;
+		color: var(--color-main-text);
+		font-weight: 500;
+		cursor: pointer;
 
-		&::-webkit-details-marker {
-			display: none;
+		&:hover {
+			background-color: var(--color-background-hover);
 		}
 
 		&:focus-visible {
 			outline: 2px solid var(--color-primary-element);
-			outline-offset: 2px;
-		}
-
-		&::after {
-			content: '';
-			display: inline-block;
-			width: 0;
-			height: 0;
-			margin-inline-start: auto;
-			border-block-start: 5px solid transparent;
-			border-block-end: 5px solid transparent;
-			border-inline-start: 6px solid currentColor;
-			transition: transform 0.15s ease-in-out;
+			outline-offset: -2px;
+			background-color: var(--color-background-hover);
 		}
 	}
 
-	@media (prefers-reduced-motion: reduce) {
-		.share-section__summary::after {
-			transition: none;
-		}
+	&__title {
+		text-align: start;
 	}
 
-	.share-hint {
-		margin-top: 0.5em;
+	&__content {
+		padding: 0 calc(var(--default-grid-baseline) * 3) calc(var(--default-grid-baseline) * 3);
+	}
+
+	&__hint {
+		font-size: 0.85em;
+		color: var(--color-text-maxcontrast);
+		margin: 0 0 calc(var(--default-grid-baseline) * 3) 0;
 	}
 }
 
@@ -450,11 +427,7 @@ export default {
 	flex-wrap: wrap;
 	align-items: center;
 	justify-content: space-between;
-	gap: 0.75em;
-
-	.action-buttons__primary {
-		margin-inline-start: auto;
-	}
+	gap: calc(var(--default-grid-baseline) * 3);
 
 	@media (max-width: 480px) {
 		flex-direction: column;

--- a/src/components/Ocm/OcmInviteDetails.vue
+++ b/src/components/Ocm/OcmInviteDetails.vue
@@ -9,8 +9,8 @@
 		<NcEmptyContent
 			v-if="!invite"
 			class="empty-content"
-			:name="t('contacts', 'No invite selected')"
-			:description="t('contacts', 'Select an invite on the list to begin')">
+			:name="t('contacts', 'No invitation selected')"
+			:description="t('contacts', 'Select an invitation on the list to begin')">
 			<template #icon>
 				<IconAccountSwitchOutline :size="20" />
 			</template>
@@ -18,7 +18,7 @@
 
 		<template v-else>
 			<div class="invite-details">
-				<h2>{{ t('contacts', 'OCM invite') }}</h2>
+				<h2>{{ t('contacts', 'Invitation') }}</h2>
 
 				<div class="invite-info">
 					<div v-if="invite.recipientName" class="info-row">
@@ -60,7 +60,7 @@
 						@copy="onCopyAction" />
 				</details>
 				<div v-else class="share-section" data-testid="ocm-invite-share-section">
-					<h3>{{ t('contacts', 'Share invite') }}</h3>
+					<h3>{{ t('contacts', 'Share invitation') }}</h3>
 					<p class="share-hint">
 						{{ t('contacts', 'The invite link is the easiest way to share. Invite codes like token@provider are for manual acceptance.') }}
 					</p>
@@ -76,8 +76,16 @@
 				<!-- Action buttons -->
 				<div class="action-buttons">
 					<NcButton
+						variant="error"
+						class="action-buttons__revoke"
+						data-testid="ocm-invite-revoke-btn"
+						@click="onRevoke">
+						{{ t('contacts', 'Revoke invitation') }}
+					</NcButton>
+					<NcButton
 						v-if="invite.recipientEmail"
 						variant="primary"
+						class="action-buttons__primary"
 						data-testid="ocm-invite-resend-btn"
 						@click="onResend">
 						<template #icon>
@@ -88,18 +96,13 @@
 					<NcButton
 						v-else
 						variant="primary"
+						class="action-buttons__primary"
 						data-testid="ocm-invite-attach-email-btn"
 						@click="openAttachEmailForm">
 						<template #icon>
 							<EmailFastOutlineIcon :size="20" />
 						</template>
 						{{ t('contacts', 'Send via email') }}
-					</NcButton>
-					<NcButton
-						variant="error"
-						data-testid="ocm-invite-revoke-btn"
-						@click="onRevoke">
-						{{ t('contacts', 'Revoke invite') }}
 					</NcButton>
 				</div>
 			</div>
@@ -108,7 +111,7 @@
 		<Modal
 			v-if="showAttachEmailForm"
 			v-model:show="showAttachEmailForm"
-			:name="t('contacts', 'Send invite via email')"
+			:name="t('contacts', 'Send invitation via email')"
 			:no-close="submittingAttachEmail">
 			<OcmAttachEmailForm
 				:loading="submittingAttachEmail"
@@ -380,14 +383,14 @@ export default {
 
 .share-section {
 	margin-bottom: 1.5em;
-	padding: 1em;
-	background: var(--color-background-dark);
+	padding: calc(var(--default-grid-baseline) * 2);
+	border: 1px solid var(--color-border);
 	border-radius: var(--border-radius-large);
 
 	.share-hint {
 		font-size: 0.85em;
 		color: var(--color-text-maxcontrast);
-		margin-bottom: 0.75em;
+		margin: 0 0 0.75em 0;
 	}
 }
 
@@ -444,10 +447,24 @@ export default {
 
 .action-buttons {
 	display: flex;
-	gap: 0.5em;
+	flex-wrap: wrap;
+	align-items: center;
+	justify-content: space-between;
+	gap: 0.75em;
 
-	@media (max-width: 400px) {
+	.action-buttons__primary {
+		margin-inline-start: auto;
+	}
+
+	@media (max-width: 480px) {
 		flex-direction: column;
+		align-items: stretch;
+
+		.action-buttons__primary,
+		.action-buttons__revoke {
+			margin-inline-start: 0;
+			width: 100%;
+		}
 	}
 }
 </style>

--- a/src/components/Ocm/OcmInviteForm.vue
+++ b/src/components/Ocm/OcmInviteForm.vue
@@ -4,9 +4,10 @@
 -->
 
 <template>
-	<div class="contact-header__infos">
-		<h5>{{ t('contacts', 'Invite someone outside your organization to collaborate.') }}</h5>
-		<p>{{ t('contacts', 'After the invitee accepts the invite, both of you will appear in each other\'s contacts list and you can start sharing data with each other.') }}</p>
+	<div class="ocm-invite-form">
+		<p class="ocm-invite-form__intro">
+			{{ t('contacts', 'After the invitee accepts the invite, both of you will appear in each other\'s contacts list and you can start sharing data with each other.') }}
+		</p>
 
 		<div class="form-field">
 			<NcTextField
@@ -22,17 +23,17 @@
 			</p>
 		</div>
 
-		<div class="email-section">
+		<div class="ocm-invite-form__group">
 			<!-- Only show toggle if optional mail is enabled -->
-			<label v-if="optionalMailEnabled" class="email-toggle">
-				<input
-					v-model="sendEmail"
-					type="checkbox"
-					:disabled="loadingUpdate"
-					data-testid="ocm-invite-send-email-checkbox">
-				<span>{{ t('contacts', 'Send invite via email') }}</span>
-			</label>
-			<div v-if="showEmailFields" class="email-fields">
+			<NcCheckboxRadioSwitch
+				v-if="optionalMailEnabled"
+				:model-value="sendEmail"
+				:disabled="loadingUpdate"
+				data-testid="ocm-invite-send-email-checkbox"
+				@update:model-value="sendEmail = $event">
+				{{ t('contacts', 'Send invite via email') }}
+			</NcCheckboxRadioSwitch>
+			<div v-if="showEmailFields" class="ocm-invite-form__fields">
 				<NcTextField
 					type="email"
 					:label="emailLabel"
@@ -50,15 +51,28 @@
 					:rows="3"
 					:disabled="loadingUpdate"
 					data-testid="ocm-invite-message-input" />
-				<!-- CC checkbox - only show if enabled in config -->
-				<label v-if="ccSenderEnabled" class="cc-toggle">
-					<input
-						v-model="ccSender"
-						type="checkbox"
-						:disabled="loadingUpdate"
-						data-testid="ocm-invite-cc-sender-checkbox">
-					<span>{{ t('contacts', 'Also send a copy of this invite to me') }}</span>
-				</label>
+
+				<!-- Collapsible preview of the email the recipient will receive -->
+				<div class="ocm-invite-form__preview">
+					<NcButton
+						variant="tertiary"
+						class="ocm-invite-form__preview-toggle"
+						:aria-expanded="showPreview"
+						data-testid="ocm-invite-preview-toggle"
+						@click="showPreview = !showPreview">
+						<template #icon>
+							<IconChevronUp v-if="showPreview" :size="20" />
+							<IconChevronDown v-else :size="20" />
+						</template>
+						{{ showPreview ? t('contacts', 'Hide email preview') : t('contacts', 'Show email preview') }}
+					</NcButton>
+					<div v-if="showPreview" class="ocm-invite-form__preview-panel" data-testid="ocm-invite-preview-panel">
+						<p v-if="previewRecipient" class="ocm-invite-form__preview-caption">
+							{{ t('contacts', 'This is what {recipient} will receive:', { recipient: previewRecipient }) }}
+						</p>
+						<div class="ocm-invite-form__preview-body" v-text="emailPreview" />
+					</div>
+				</div>
 			</div>
 			<p v-if="optionalMailEnabled && !sendEmail" class="hint">
 				{{ t('contacts', 'If you do not send an email, you will need to share the invite link yourself.') }}
@@ -72,12 +86,19 @@
 </template>
 
 <script>
+import { getCurrentUser } from '@nextcloud/auth'
 import { loadState } from '@nextcloud/initial-state'
-import { NcTextArea, NcTextField } from '@nextcloud/vue'
+import { NcButton, NcCheckboxRadioSwitch, NcTextArea, NcTextField } from '@nextcloud/vue'
+import IconChevronDown from 'vue-material-design-icons/ChevronDown.vue'
+import IconChevronUp from 'vue-material-design-icons/ChevronUp.vue'
 
 export default {
 	name: 'OcmInviteForm',
 	components: {
+		IconChevronDown,
+		IconChevronUp,
+		NcButton,
+		NcCheckboxRadioSwitch,
 		NcTextField,
 		NcTextArea,
 	},
@@ -98,14 +119,13 @@ export default {
 	data() {
 		const config = loadState('contacts', 'ocmInvitesConfig', {
 			optionalMail: false,
-			ccSender: true,
-			encodedCopyButton: false,
 		})
+		const currentUser = getCurrentUser()
 		return {
 			sendEmail: !config.optionalMail,
-			ccSender: false,
 			optionalMailEnabled: config.optionalMail,
-			ccSenderEnabled: config.ccSender,
+			showPreview: false,
+			senderName: currentUser?.displayName || currentUser?.uid || '',
 		}
 	},
 
@@ -114,6 +134,37 @@ export default {
 			// Always show if optional mail is disabled (email required)
 			// Otherwise show based on sendEmail toggle
 			return !this.optionalMailEnabled || this.sendEmail
+		},
+
+		previewRecipient() {
+			return (this.ocmInvite.email ?? '').trim()
+		},
+
+		/**
+		 * Plain-text reconstruction of the invitation email body so the sender
+		 * can preview how their personal message reads in context. Mirrors the
+		 * body assembled server-side in FederatedInvitesController; the actual
+		 * invite link and code are added when the invitation is sent.
+		 *
+		 * @return {string}
+		 */
+		emailPreview() {
+			const message = (this.ocmInvite.message ?? '').trim()
+			const lines = [
+				this.t('contacts', 'Hi there,'),
+				'',
+				this.t('contacts', '{name} invites you to exchange cloud accounts and contact information.', { name: this.senderName }),
+				this.t('contacts', 'This will allow you to share data with each other.'),
+			]
+			if (message !== '') {
+				lines.push('---', message, '---')
+			}
+			lines.push(
+				'',
+				this.t('contacts', 'To accept this invite, click the link below and sign in with your cloud provider:'),
+				this.t('contacts', 'The invite link and code are added automatically when you send the invitation.'),
+			)
+			return lines.join('\n')
 		},
 
 		emailRequired() {
@@ -149,14 +200,9 @@ export default {
 				if (!newVal && oldVal !== undefined) {
 					patch.email = ''
 					patch.message = ''
-					this.ccSender = false
 				}
 				this.updateInvite(patch)
 			},
-		},
-
-		ccSender(newVal) {
-			this.updateInvite({ ccSender: newVal })
 		},
 	},
 
@@ -177,75 +223,72 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.contact-header__infos {
-	margin: 1em;
+.ocm-invite-form {
+	margin: calc(var(--default-grid-baseline) * 4);
 
-	h5 {
-		margin: 0 0 0.5em 0;
-	}
-
-	> p {
-		margin-bottom: 1.5em;
+	&__intro {
+		margin-bottom: calc(var(--default-grid-baseline) * 6);
 		color: var(--color-text-maxcontrast);
 	}
 
 	.hint {
 		font-size: 0.85em;
 		color: var(--color-text-maxcontrast);
-		margin-top: 0.5em;
+		margin-top: calc(var(--default-grid-baseline) * 2);
 		margin-bottom: 0;
 	}
 
 	.form-field {
-		margin-bottom: 1.5em;
+		margin-bottom: calc(var(--default-grid-baseline) * 6);
 	}
 
-	.email-section {
-		padding: calc(var(--default-grid-baseline) * 2);
+	&__group {
+		display: flex;
+		flex-direction: column;
+		gap: calc(var(--default-grid-baseline) * 3);
+		padding: calc(var(--default-grid-baseline) * 3);
 		border: 1px solid var(--color-border);
 		border-radius: var(--border-radius-large);
-		margin-bottom: 1.5em;
+		margin-bottom: calc(var(--default-grid-baseline) * 6);
+		background-color: transparent;
+	}
 
-		.email-toggle,
-		.cc-toggle {
-			display: flex;
-			align-items: center;
-			gap: calc(var(--default-grid-baseline) * 2);
-			cursor: pointer;
-			user-select: none;
-			margin-bottom: calc(var(--default-grid-baseline) * 2);
+	&__fields {
+		display: flex;
+		flex-direction: column;
+		gap: calc(var(--default-grid-baseline) * 3);
+	}
 
-			input[type="checkbox"] {
-				width: 18px;
-				height: 18px;
-				cursor: pointer;
-				accent-color: var(--color-primary);
-			}
-		}
+	&__preview {
+		display: flex;
+		flex-direction: column;
+		gap: calc(var(--default-grid-baseline) * 2);
+	}
 
-		.cc-toggle {
-			margin-top: calc(var(--default-grid-baseline) * 2);
-			margin-bottom: 0;
+	&__preview-toggle {
+		margin-inline-start: 0;
+	}
 
-			span {
-				font-size: 0.9em;
-			}
-		}
+	&__preview-caption {
+		font-size: 0.85em;
+		color: var(--color-text-maxcontrast);
+		margin: 0 0 calc(var(--default-grid-baseline) * 2) 0;
+	}
 
-		.email-fields {
-			display: flex;
-			flex-direction: column;
-			gap: calc(var(--default-grid-baseline) * 2);
-			margin-top: calc(var(--default-grid-baseline) * 2);
-		}
-
-		.hint {
-			margin-top: calc(var(--default-grid-baseline) * 2);
-		}
+	&__preview-body {
+		white-space: pre-wrap;
+		overflow-wrap: anywhere;
+		font-size: 0.9em;
+		line-height: 1.5;
+		padding: calc(var(--default-grid-baseline) * 3);
+		border: 1px solid var(--color-border);
+		border-radius: var(--border-radius-large);
+		background-color: var(--color-background-hover);
+		color: var(--color-main-text);
 	}
 
 	.actions {
-		margin-top: 1em;
+		margin-top: calc(var(--default-grid-baseline) * 4);
 	}
 }
 </style>

--- a/src/components/Ocm/OcmInviteForm.vue
+++ b/src/components/Ocm/OcmInviteForm.vue
@@ -201,8 +201,8 @@ export default {
 	}
 
 	.email-section {
-		padding: 1em;
-		background: var(--color-background-dark);
+		padding: calc(var(--default-grid-baseline) * 2);
+		border: 1px solid var(--color-border);
 		border-radius: var(--border-radius-large);
 		margin-bottom: 1.5em;
 
@@ -210,10 +210,10 @@ export default {
 		.cc-toggle {
 			display: flex;
 			align-items: center;
-			gap: 0.5em;
+			gap: calc(var(--default-grid-baseline) * 2);
 			cursor: pointer;
 			user-select: none;
-			margin-bottom: 0.5em;
+			margin-bottom: calc(var(--default-grid-baseline) * 2);
 
 			input[type="checkbox"] {
 				width: 18px;
@@ -221,18 +221,13 @@ export default {
 				cursor: pointer;
 				accent-color: var(--color-primary);
 			}
-
-			span {
-				font-weight: 500;
-			}
 		}
 
 		.cc-toggle {
-			margin-top: 0.5em;
+			margin-top: calc(var(--default-grid-baseline) * 2);
 			margin-bottom: 0;
 
 			span {
-				font-weight: normal;
 				font-size: 0.9em;
 			}
 		}
@@ -240,12 +235,12 @@ export default {
 		.email-fields {
 			display: flex;
 			flex-direction: column;
-			gap: 1em;
-			margin-top: 1em;
+			gap: calc(var(--default-grid-baseline) * 2);
+			margin-top: calc(var(--default-grid-baseline) * 2);
 		}
 
 		.hint {
-			margin-top: 0.5em;
+			margin-top: calc(var(--default-grid-baseline) * 2);
 		}
 	}
 

--- a/src/components/Ocm/OcmInviteShareActions.vue
+++ b/src/components/Ocm/OcmInviteShareActions.vue
@@ -4,29 +4,51 @@
 -->
 
 <template>
-	<div class="share-buttons">
-		<NcButton variant="secondary" data-testid="ocm-invite-link-copy-btn" @click="emitCopy(wayfLink, clipboardKinds.inviteLink)">
-			<template #icon>
-				<ContentCopyIcon :size="20" />
-			</template>
-			{{ t('contacts', 'Copy invite link') }}
-		</NcButton>
-		<NcButton variant="secondary" data-testid="ocm-invite-token-copy-btn" @click="emitCopy(plainInviteString, clipboardKinds.inviteCode)">
-			<template #icon>
-				<ContentCopyIcon :size="20" />
-			</template>
-			{{ t('contacts', 'Copy invite code') }}
-		</NcButton>
-		<NcButton
-			v-if="encodedCopyButtonEnabled"
-			variant="secondary"
-			data-testid="ocm-invite-base64-copy-btn"
-			@click="emitCopy(base64InviteString, clipboardKinds.encodedInvite)">
-			<template #icon>
-				<ContentCopyIcon :size="20" />
-			</template>
-			{{ t('contacts', 'Copy encoded invite code') }}
-		</NcButton>
+	<div class="share-rows">
+		<div class="share-row">
+			<span class="share-row__label">{{ t('contacts', 'Invite link') }}</span>
+			<span class="share-row__value" :title="inviteLink">{{ inviteLink }}</span>
+			<NcButton
+				variant="tertiary-no-background"
+				:aria-label="t('contacts', 'Copy invite link to clipboard')"
+				:title="t('contacts', 'Copy invite link to clipboard')"
+				data-testid="ocm-invite-link-copy-btn"
+				@click="emitCopy(inviteLink, clipboardKinds.inviteLink)">
+				<template #icon>
+					<ContentCopyIcon :size="20" />
+				</template>
+			</NcButton>
+		</div>
+
+		<div class="share-row">
+			<span class="share-row__label">{{ t('contacts', 'Invite code') }}</span>
+			<span class="share-row__value" :title="inviteCode">{{ inviteCode }}</span>
+			<NcButton
+				variant="tertiary-no-background"
+				:aria-label="t('contacts', 'Copy invite code to clipboard')"
+				:title="t('contacts', 'Copy invite code to clipboard')"
+				data-testid="ocm-invite-code-copy-btn"
+				@click="emitCopy(inviteCode, clipboardKinds.inviteCode)">
+				<template #icon>
+					<ContentCopyIcon :size="20" />
+				</template>
+			</NcButton>
+		</div>
+
+		<div v-if="encodedCopyButtonEnabled" class="share-row">
+			<span class="share-row__label">{{ t('contacts', 'Encoded invite') }}</span>
+			<span class="share-row__value" :title="encodedInvite">{{ encodedInvite }}</span>
+			<NcButton
+				variant="tertiary-no-background"
+				:aria-label="t('contacts', 'Copy encoded invite to clipboard')"
+				:title="t('contacts', 'Copy encoded invite to clipboard')"
+				data-testid="ocm-invite-base64-copy-btn"
+				@click="emitCopy(encodedInvite, clipboardKinds.encodedInvite)">
+				<template #icon>
+					<ContentCopyIcon :size="20" />
+				</template>
+			</NcButton>
+		</div>
 	</div>
 </template>
 
@@ -47,19 +69,19 @@ export default {
 			default: false,
 		},
 
-		wayfLink: {
+		inviteLink: {
 			type: String,
 			required: true,
 		},
 
-		plainInviteString: {
+		inviteCode: {
 			type: String,
-			required: true,
+			default: '',
 		},
 
-		base64InviteString: {
+		encodedInvite: {
 			type: String,
-			required: true,
+			default: '',
 		},
 
 		clipboardKinds: {
@@ -79,14 +101,37 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.share-buttons {
+.share-rows {
 	display: flex;
 	flex-direction: column;
-	gap: 0.5em;
+}
 
-	:deep(.button-vue) {
-		width: 100%;
-		justify-content: flex-start;
+.share-row {
+	display: flex;
+	align-items: center;
+	gap: calc(var(--default-grid-baseline) * 2);
+	padding: calc(var(--default-grid-baseline) * 2) 0;
+	border-bottom: 1px solid var(--color-border);
+
+	&:last-child {
+		border-bottom: none;
+	}
+
+	&__label {
+		flex: 0 0 calc(var(--default-grid-baseline) * 28);
+		color: var(--color-text-maxcontrast);
+		font-size: 0.9em;
+	}
+
+	&__value {
+		flex: 1;
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+		font-size: 0.85em;
+		color: var(--color-main-text);
 	}
 }
 </style>

--- a/src/components/Ocm/OcmInvitesList.vue
+++ b/src/components/Ocm/OcmInvitesList.vue
@@ -7,7 +7,7 @@
 	<AppContentList class="content-list">
 		<div class="contacts-list__header">
 			<div class="search-contacts-field">
-				<input v-model="query" type="text" :placeholder="t('contacts', 'Search invites …')">
+				<input v-model="query" type="text" :placeholder="t('contacts', 'Search invites...')">
 			</div>
 		</div>
 		<VList

--- a/src/components/Ocm/OcmInvitesListItem.vue
+++ b/src/components/Ocm/OcmInvitesListItem.vue
@@ -59,7 +59,7 @@ export default {
 
 .envelope {
 	.app-content-list-item-icon {
-		height: 40px; // To prevent some unexpected spacing below the avatar
+		height: calc(var(--default-grid-baseline) * 10); // To prevent some unexpected spacing below the avatar
 	}
 
 	&__subtitle {

--- a/src/components/Ocm/Wayf.vue
+++ b/src/components/Ocm/Wayf.vue
@@ -11,65 +11,68 @@
 					<h2>{{ t('contacts', 'Providers') }}</h2>
 					<p>{{ t('contacts', 'Where are you from?') }}</p>
 					<p>{{ t('contacts', 'Please tell us your cloud provider.') }}</p>
-					<div v-if="hasFederationData">
-						<NcTextField
-							id="wayf-search"
-							v-model="query"
-							:label="t('contacts', 'Type to search')"
-							type="search"
-							name="search">
-							<template #icon>
-								<Magnify :size="20" />
-							</template>
-						</NcTextField>
-						<div v-if="hasVisibleProviders">
-							<div
-								v-for="group in visibleFederations"
-								:key="group.federation">
-								<h3>{{ group.federation }}</h3>
-								<ul class="wayf-list">
-									<NcListItem
-										v-for="p in group.providers"
-										:key="p.fqdn"
-										:href="p.inviteUrl"
-										:name="p.name"
-										one-line>
-										<template #icon>
-											<NcListItemIcon :name="p.name" :subname="p.fqdn">
-												<WeatherCloudyArrowRight :size="20" />
-											</NcListItemIcon>
-										</template>
-									</NcListItem>
-								</ul>
+					<NcFormBox class="wayf-form">
+						<div v-if="hasFederationData" class="wayf-search">
+							<NcTextField
+								id="wayf-search"
+								v-model="query"
+								:label="t('contacts', 'Type to search')"
+								type="search"
+								name="search">
+								<template #icon>
+									<Magnify :size="20" />
+								</template>
+							</NcTextField>
+							<div v-if="hasVisibleProviders">
+								<div
+									v-for="group in visibleFederations"
+									:key="group.federation">
+									<h3>{{ group.federation }}</h3>
+									<ul class="wayf-list">
+										<NcListItem
+											v-for="p in group.providers"
+											:key="p.fqdn"
+											:href="p.inviteUrl"
+											:name="p.name"
+											one-line>
+											<template #icon>
+												<NcListItemIcon :name="p.name" :subname="p.fqdn">
+													<WeatherCloudyArrowRight :size="20" />
+												</NcListItemIcon>
+											</template>
+										</NcListItem>
+									</ul>
+								</div>
 							</div>
+							<p v-else class="wayf-empty">
+								{{ t('contacts', 'No providers match your search.') }}
+							</p>
 						</div>
 						<p v-else class="wayf-empty">
-							{{ t('contacts', 'No providers match your search.') }}
+							{{ t('contacts', 'No providers are currently available.') }}
 						</p>
-					</div>
-					<p v-else class="wayf-empty">
-						{{ t('contacts', 'No providers are currently available.') }}
-					</p>
-					<form class="wayf-manual-form" @submit.prevent="goToManualProvider">
-						<NcTextField
-							id="wayf-manual"
-							v-model="manualProvider"
-							:label="t('contacts', 'No provider listed? Enter one manually.')"
-							type="text"
-							name="manual">
-							<template #icon>
-								<WeatherCloudyArrowRight :size="20" />
-							</template>
-						</NcTextField>
-						<div class="wayf-manual-actions">
-							<NcButton type="submit">
-								{{ t('contacts', 'Continue') }}
-							</NcButton>
+						<div class="wayf-manual">
+							<NcTextField
+								id="wayf-manual"
+								v-model="manualProvider"
+								:label="t('contacts', 'No provider listed? Enter one manually.')"
+								type="text"
+								name="manual"
+								@keydown.enter.prevent="goToManualProvider">
+								<template #icon>
+									<WeatherCloudyArrowRight :size="20" />
+								</template>
+							</NcTextField>
+							<div class="wayf-manual-actions">
+								<NcButton variant="primary" @click="goToManualProvider">
+									{{ t('contacts', 'Continue') }}
+								</NcButton>
+							</div>
 						</div>
-					</form>
+					</NcFormBox>
 				</div>
 				<div v-else>
-					<p>{{ t('contacts', 'You need an invite code for this feature to work.') }}</p>
+					<p>{{ t('contacts', 'You need an invite link for this feature to work.') }}</p>
 				</div>
 			</div>
 		</template>
@@ -87,6 +90,7 @@ import {
 	NcListItemIcon,
 	NcTextField,
 } from '@nextcloud/vue'
+import NcFormBox from '@nextcloud/vue/components/NcFormBox'
 import Magnify from 'vue-material-design-icons/Magnify.vue'
 import WeatherCloudyArrowRight from 'vue-material-design-icons/WeatherCloudyArrowRight.vue'
 
@@ -95,6 +99,7 @@ export default {
 	components: {
 		Magnify,
 		NcButton,
+		NcFormBox,
 		NcGuestContent,
 		NcListItem,
 		NcListItemIcon,
@@ -218,7 +223,7 @@ export default {
 #contacts-wayf {
   background: var(--color-background-plain);
   color: var(--color-background-plain-text);
-  border-radius: 8px;
+  border-radius: var(--border-radius-large);
 }
 
 .wayf-list {
@@ -231,10 +236,10 @@ export default {
 .wayf-list > li {
   align-items: center;
   justify-content: space-between;
-  gap: 0.5rem;
+  gap: calc(var(--default-grid-baseline) * 2);
 
-  padding: 0.75rem 1rem;
-  margin: 0.25rem 0;
+  padding: calc(var(--default-grid-baseline) * 3) calc(var(--default-grid-baseline) * 4);
+  margin: var(--default-grid-baseline) 0;
 
   background-color: var(--color-background-dark);
   color: var(--color-main-text);
@@ -254,17 +259,17 @@ export default {
 }
 
 .wayf-empty {
-  margin-block: 0.75rem 1rem;
+  margin-block: calc(var(--default-grid-baseline) * 3) calc(var(--default-grid-baseline) * 4);
   color: var(--color-text-maxcontrast);
 }
 
-.wayf-manual-form {
-  margin-top: 1rem;
+.wayf-manual {
+  margin-top: calc(var(--default-grid-baseline) * 4);
 }
 
 .wayf-manual-actions {
   display: flex;
   justify-content: flex-end;
-  margin-top: 0.5rem;
+  margin-top: calc(var(--default-grid-baseline) * 2);
 }
 </style>

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -40,7 +40,6 @@ export const SECTION_EXTERNAL_INVITATIONS = t('contacts', 'External invitations'
 export const GROUP_ALL_OCM_INVITES = t('contacts', 'All invitations')
 export const OCM_INVITES_CONFIG_KEYS = {
 	optionalMail: 'ocm_invites_optional_mail',
-	ccSender: 'ocm_invites_cc_sender',
 	encodedCopyButton: 'ocm_invites_encoded_copy_button',
 } as const
 

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -36,7 +36,8 @@ export const ROUTE_NAME_INVITE_ACCEPT_DIALOG = 'invite_accept_dialog'
 export const ROUTE_ALL_OCM_INVITES = 'ocm-invites'
 export const ROUTE_NAME_ALL_OCM_INVITES = 'all_ocm_invites'
 export const ROUTE_NAME_OCM_INVITE = 'ocm_invite'
-export const GROUP_ALL_OCM_INVITES = t('contacts', 'All invites')
+export const SECTION_EXTERNAL_INVITATIONS = t('contacts', 'External invitations')
+export const GROUP_ALL_OCM_INVITES = t('contacts', 'All invitations')
 export const OCM_INVITES_CONFIG_KEYS = {
 	optionalMail: 'ocm_invites_optional_mail',
 	ccSender: 'ocm_invites_cc_sender',

--- a/src/store/ocminvites.ts
+++ b/src/store/ocminvites.ts
@@ -28,7 +28,6 @@ interface NewInvitePayload {
 	email?: string
 	message?: string
 	note?: string
-	ccSender?: boolean
 }
 
 interface AttachEmailPayload {
@@ -122,7 +121,6 @@ const useOcmInvitesStore = defineStore('ocminvites', {
 				email: invite.email || '',
 				message: invite.message || '',
 				note: invite.note || '',
-				ccSender: invite.ccSender || false,
 			}
 			let response
 			try {

--- a/src/views/Contacts.vue
+++ b/src/views/Contacts.vue
@@ -9,8 +9,11 @@
 		<RootNavigation
 			:contacts-list="contactsList"
 			:loading="loadingContacts || loadingCircles || loadingInvites"
+			:invite-actions-enabled="!!defaultAddressbook"
 			:selected-group="selectedGroup"
-			:selected-contact="selectedContact">
+			:selected-contact="selectedContact"
+			@open-create-invite="newInvite"
+			@open-accept-invite="manualInviteAccept">
 			<div class="import-and-new-contact-buttons">
 				<SettingsImportContacts v-if="!loadingContacts && isEmptyGroup && !isChartView && !isCirclesView" />
 				<!-- new-contact-button -->
@@ -24,30 +27,6 @@
 						<IconAdd :size="20" />
 					</template>
 					{{ isCirclesView ? t('contacts', 'Add member') : t('contacts', 'New contact') }}
-				</NcButton>
-				<!-- invite-contact-button -->
-				<NcButton
-					v-if="isOcmInvitesEnabled && !loadingInvites"
-					variant="secondary"
-					wide
-					:disabled="!defaultAddressbook"
-					@click="newInvite">
-					<template #icon>
-						<IconAccountSwitchOutline :size="20" />
-					</template>
-					{{ t('contacts', 'Invite contact') }}
-				</NcButton>
-				<!-- accept-invite-button -->
-				<NcButton
-					v-if="isOcmInvitesEnabled && !loadingInvites"
-					variant="secondary"
-					wide
-					:disabled="!defaultAddressbook"
-					@click="manualInviteAccept">
-					<template #icon>
-						<IconAccountArrowDownOutline :size="20" />
-					</template>
-					{{ t('contacts', 'Accept invite') }}
 				</NcButton>
 			</div>
 		</RootNavigation>
@@ -118,7 +97,7 @@
 		</Modal>
 		<Modal
 			v-if="showManualInvite"
-			:name="t('contacts', 'Accept invite')"
+			:name="t('contacts', 'Accept invitation')"
 			:no-close="loadingUpdate"
 			@close="manualInviteCancel">
 			<OcmAcceptForm
@@ -130,7 +109,7 @@
 		<!-- invite accept dialog -->
 		<Modal
 			v-if="showInviteAcceptDialog"
-			:name="t('contacts', 'Accept invite')"
+			:name="t('contacts', 'Accept invitation')"
 			:no-close="loadingUpdate"
 			@close="cancelInvite">
 			<OcmInviteAccept :token="inviteToken" :provider="inviteProvider">
@@ -175,8 +154,6 @@ import {
 } from '@nextcloud/vue'
 import ICAL from 'ical.js'
 import { mapStores } from 'pinia'
-import IconAccountArrowDownOutline from 'vue-material-design-icons/AccountArrowDownOutline.vue'
-import IconAccountSwitchOutline from 'vue-material-design-icons/AccountSwitchOutline.vue'
 import IconCancel from 'vue-material-design-icons/Cancel.vue'
 import IconCheck from 'vue-material-design-icons/Check.vue'
 import IconAdd from 'vue-material-design-icons/Plus.vue'
@@ -212,14 +189,12 @@ const _default = {
 
 	components: {
 		NcButton,
-		IconAccountArrowDownOutline,
 		CircleContent,
 		ChartContent,
 		ContactsContent,
 		ContactsPicker,
 		Content,
 		ImportView,
-		IconAccountSwitchOutline,
 		IconAdd,
 		IconCancel,
 		IconCheck,

--- a/src/views/Contacts.vue
+++ b/src/views/Contacts.vue
@@ -65,23 +65,14 @@
 		<!-- new invite form -->
 		<Modal
 			v-if="showNewInviteForm"
-			:name="t('contacts', 'Invite someone to share contacts')"
+			:name="t('contacts', 'Invite someone outside your organization to collaborate.')"
 			:no-close="loadingUpdate"
 			@close="cancelNewInvite">
 			<OcmInviteForm v-model:ocm-invite="ocmInvite" :loading-update="loadingUpdate">
 				<template #new-invite-actions>
 					<div class="new-invite-form__buttons-row">
 						<NcButton
-							:disabled="loadingUpdate"
-							data-testid="ocm-invite-new-submit-btn"
-							@click="sendNewInvite">
-							<template #icon>
-								<IconLoading v-if="loadingUpdate" :size="20" />
-								<IconCheck v-else :size="20" />
-							</template>
-							{{ newInvitePrimaryLabel }}
-						</NcButton>
-						<NcButton
+							variant="tertiary"
 							:disabled="loadingUpdate"
 							data-testid="ocm-invite-new-cancel-btn"
 							@click="cancelNewInvite">
@@ -90,6 +81,17 @@
 								<IconCancel v-else :size="20" />
 							</template>
 							{{ t("contacts", "Cancel") }}
+						</NcButton>
+						<NcButton
+							variant="primary"
+							:disabled="loadingUpdate"
+							data-testid="ocm-invite-new-submit-btn"
+							@click="sendNewInvite">
+							<template #icon>
+								<IconLoading v-if="loadingUpdate" :size="20" />
+								<IconCheck v-else :size="20" />
+							</template>
+							{{ newInvitePrimaryLabel }}
 						</NcButton>
 					</div>
 				</template>
@@ -115,19 +117,19 @@
 			<OcmInviteAccept :token="inviteToken" :provider="inviteProvider">
 				<template #accept-invite-actions>
 					<div class="invite-accept-form__buttons-row">
-						<NcButton :disabled="loadingUpdate" @click="acceptInvite">
-							<template #icon>
-								<IconLoading v-if="loadingUpdate" :size="20" />
-								<IconCheck v-else :size="20" />
-							</template>
-							{{ t("contacts", "Accept") }}
-						</NcButton>
-						<NcButton :disabled="loadingUpdate" @click="cancelInvite">
+						<NcButton variant="tertiary" :disabled="loadingUpdate" @click="cancelInvite">
 							<template #icon>
 								<IconLoading v-if="loadingUpdate" :size="20" />
 								<IconCancel v-else :size="20" />
 							</template>
 							{{ t("contacts", "Cancel") }}
+						</NcButton>
+						<NcButton variant="primary" :disabled="loadingUpdate" @click="acceptInvite">
+							<template #icon>
+								<IconLoading v-if="loadingUpdate" :size="20" />
+								<IconCheck v-else :size="20" />
+							</template>
+							{{ t("contacts", "Accept") }}
 						</NcButton>
 					</div>
 				</template>
@@ -236,11 +238,6 @@ const _default = {
 			inviteProvider: inviteProvider,
 			ocmInvite: { email: '', message: '', note: '' },
 			loadingUpdate: false,
-			ocmInvitesConfig: loadState('contacts', 'ocmInvitesConfig', {
-				optionalMail: false,
-				ccSender: true,
-				encodedCopyButton: false,
-			}),
 		}
 	},
 
@@ -749,6 +746,7 @@ export default _default
 
 .invite-accept-form__buttons-row {
   display: flex;
+  justify-content: flex-end;
   gap: calc(var(--default-grid-baseline) * 2);
   margin-top: calc(var(--default-grid-baseline) * 4);
 }
@@ -758,6 +756,7 @@ export default _default
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  justify-content: space-between;
+  gap: calc(var(--default-grid-baseline) * 2);
+  justify-content: flex-end;
 }
 </style>

--- a/tests/javascript/store/ocminvites.test.js
+++ b/tests/javascript/store/ocminvites.test.js
@@ -252,7 +252,6 @@ describe('ocminvites store', () => {
 				email: 'recipient@example.org',
 				message: 'See you soon',
 				note: 'CERN contact',
-				ccSender: true,
 			})
 
 			expect(axios.post).toHaveBeenCalledTimes(1)
@@ -260,7 +259,6 @@ describe('ocminvites store', () => {
 				email: 'recipient@example.org',
 				message: 'See you soon',
 				note: 'CERN contact',
-				ccSender: true,
 			})
 			expect(axios.get).toHaveBeenCalledTimes(1)
 			expect(store.ocmInvites['new-token']).toBeDefined()
@@ -277,7 +275,6 @@ describe('ocminvites store', () => {
 				email: '',
 				message: '',
 				note: '',
-				ccSender: false,
 			})
 		})
 

--- a/tests/unit/Controller/FederatedInvitesControllerTest.php
+++ b/tests/unit/Controller/FederatedInvitesControllerTest.php
@@ -532,7 +532,7 @@ class FederatedInvitesControllerTest extends TestCase {
 		$this->urlGenerator->method('linkToRoute')->with('contacts.page.index')->willReturn('/apps/contacts/');
 		$this->urlGenerator->method('getAbsoluteURL')->willReturnCallback(static fn (string $path): string => 'https://local.example' . $path);
 
-		$response = $this->controller->createInvite('', '', 'mesh peer', false);
+		$response = $this->controller->createInvite('', '', 'mesh peer');
 
 		$this->assertSame(Http::STATUS_OK, $response->getStatus());
 		$this->assertNotNull($capturedInvite);
@@ -569,7 +569,7 @@ class FederatedInvitesControllerTest extends TestCase {
 		$this->urlGenerator->method('linkToRoute')->with('contacts.page.index')->willReturn('/apps/contacts/');
 		$this->urlGenerator->method('getAbsoluteURL')->willReturnCallback(static fn (string $path): string => 'https://local.example' . $path);
 
-		$response = $this->controller->createInvite('recipient@example.org', '<b>hello</b>', '', false);
+		$response = $this->controller->createInvite('recipient@example.org', '<b>hello</b>', '');
 
 		$this->assertSame(Http::STATUS_OK, $response->getStatus());
 		$this->assertStringContainsString('&lt;b&gt;hello&lt;/b&gt;', (string)$capturedHtml);
@@ -583,7 +583,7 @@ class FederatedInvitesControllerTest extends TestCase {
 			->willReturn(false);
 		$this->mapper->expects($this->never())->method('insert');
 
-		$response = $this->controller->createInvite('', '', '', false);
+		$response = $this->controller->createInvite('', '', '');
 
 		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
 		$this->assertSame('Email address is required.', $response->getData()['message']);


### PR DESCRIPTION
# OCM Invites: Optional Email and UI Improvements

### Email is Now Optional

The backend was already set up to handle NULL emails (thanks, database schema!), but the code was still checking for it. Now you can create invites without email, perfect for when you just want to share a link manually. (in my case test suite)

### Invite Labels

Now there's an optional label field so you can tag invites with something like "Giuseppe from CERN" or "Test invite for demo". Makes searching way easier, especially for link-only invites. 
I just reused the existing `recipient_name` column, so no database migrations needed. until the invite accepted by remote the label lives there, after it would be replaced by the actual name returned by remote

### UI
- Better spacing and layout
- Added a checkbox for "Send invite via email", email fields only appear when you check it
- Clear hint text about what happens if you skip email

The invite details page :
- Just the essential info, no redundant input fields
- Three handy copy buttons in a grid: invite link, token, and base64

Everything is backward compatible, existing invites with email work exactly like before. No breaking changes here as far as I've tested, if you test it on the SUNET test drive it would be great!

### Gallery

#### Pop up changes, email toggle, invalid or not configured smtp error, etc
<img width="2507" height="1399" alt="Screenshot 2025-11-30 112601" src="https://github.com/user-attachments/assets/5aff5254-782c-4029-855b-bbd424e26ad5" />
<img width="2508" height="1397" alt="Screenshot 2025-11-30 112637" src="https://github.com/user-attachments/assets/e1d51681-e574-4edb-9100-53c14b00ace4" />
<img width="2508" height="1398" alt="Screenshot 2025-11-30 112618" src="https://github.com/user-attachments/assets/24972a3d-07d0-4230-b360-4363a7f55627" />
<img width="2506" height="1398" alt="Screenshot 2025-11-30 112649" src="https://github.com/user-attachments/assets/448bd08f-daf3-43ad-bdff-dd1eb73528e6" />

#### Creating a test invite with no email
<img width="2510" height="1399" alt="Screenshot 2025-11-30 112709" src="https://github.com/user-attachments/assets/95321579-3439-45dc-8d0c-f1cf75434935" />
<img width="2508" height="1399" alt="Screenshot 2025-11-30 112724" src="https://github.com/user-attachments/assets/165ff7aa-310f-4ea8-bbd5-3d7446e4daa0" />
